### PR TITLE
Fix applications of erlang:exit to remedy errors by Dialyzer

### DIFF
--- a/src/error_logger_logi.erl
+++ b/src/error_logger_logi.erl
@@ -49,7 +49,7 @@ install_opt(Options) ->
     _ = is_list(OmitReportTypes) orelse error(badarg, [Options]),
     case error_logger:add_report_handler(error_logger_logi_h, {Logger, OmitReportTypes}) of
         ok    -> ok;
-        Other -> exit({install_failed, Other}, [Logger])
+        Other -> exit({install_failed, Other, [Logger]})
     end.
 
 %% @equiv uninstall(logi:default_logger())
@@ -62,5 +62,5 @@ uninstall(Logger) ->
     case error_logger:delete_report_handler(error_logger_logi_h) of
         ok                        -> ok;
         {error, module_not_found} -> ok;
-        Other                     -> exit({uninstall_failed, Other}, [Logger])
+        Other                     -> exit({uninstall_failed, Other, [Logger]})
     end.


### PR DESCRIPTION
I have found that the current implementation of `error_logger_logi` is rejected by Dialyzer (at least with the environment of OTP 20.0):

```console
$ make init
(some texts on stdout omitted)

$ make dialyze
==> error_logger_logi (compile)
Compiled src/error_logger_logi_app.erl
Compiled src/error_logger_logi_sup.erl
Compiled src/error_logger_logi_h.erl
Compiled src/error_logger_logi.erl
dialyzer --plt .dialyzer.plt -r ebin -Werror_handling -Wrace_conditions -Wunmatched_returns
  Checking whether the PLT .dialyzer.plt is up-to-date... yes
  Proceeding with analysis...
error_logger_logi.erl:52: The call erlang:exit({'install_failed',_},[any(),...]) breaks the contract (Pid,Reason) -> 'true' when Pid :: pid() | port(), Reason :: term()
error_logger_logi.erl:65: The call erlang:exit({'uninstall_failed',_},[any(),...]) breaks the contract (Pid,Reason) -> 'true' when Pid :: pid() | port(), Reason :: term()
 done in 0m0.14s
done (warnings were emitted)
make: *** [dialyze] Error 2
```

This is probably due to brackets being in a slightly wrong place in the arguments of `exit` in `src/error_logger_logi.erl`:

```erlang
52|        Other -> exit({install_failed, Other}, [Logger])
```

This PR thereby attempts to remedy the error. The error appears to be indeed fixed:

```console
$ make dialyze
==> error_logger_logi (compile)
touch .dialyzer.plt
dialyzer --build_plt --plt .dialyzer.plt --apps erts kernel stdlib -r deps/*/ebin
  Compiling some key modules to native code... done in 0m0.26s
  Creating PLT .dialyzer.plt ...
Unknown functions:
  compile:file/2
  compile:forms/2
  compile:noenv_forms/2
  compile:output_generated/1
  crypto:block_decrypt/4
  crypto:start/0
Unknown types:
  compile:option/0
 done in 0m17.02s
done (passed successfully)
dialyzer --plt .dialyzer.plt -r ebin -Werror_handling -Wrace_conditions -Wunmatched_returns
  Checking whether the PLT .dialyzer.plt is up-to-date... yes
  Proceeding with analysis... done in 0m0.13s
done (passed successfully)
```

I would appreciate any comments.